### PR TITLE
[FIX] w3c validation

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -542,7 +542,7 @@ class ModTweetDisplayBackHelper
 			}
 			$twitter[$i]->tweet->user = '<b><a href="' . $userURL . '" rel="nofollow">' . $tweetedBy . '</a>' . $params->get('tweetUserSeparator') . '</b>';
 		}
-		$twitter[$i]->tweet->avatar = '<img align="' . $tweetAlignment . '" alt="' . $tweetedBy . '" src="' . $avatar . '" width="32px"/>';
+		$twitter[$i]->tweet->avatar = '<img alt="' . $tweetedBy . '" src="' . $avatar . '" width="32" />';
 		$twitter[$i]->tweet->text = $text;
 
 		// Make regular URLs in tweets a link


### PR DESCRIPTION
Solved two issues that generated 4 errors in W3C validation:
- attribute align => deprecated. Seems old markup as the module already uses CSS align properties.
- width is specified in px

Patched version validates W3C and width/align are working ok.

Thanks for this great module!! ;)
